### PR TITLE
[Task #70] Live session participants presence

### DIFF
--- a/backend/sozisel/lib/sozisel/application.ex
+++ b/backend/sozisel/lib/sozisel/application.ex
@@ -16,6 +16,8 @@ defmodule Sozisel.Application do
       SoziselWeb.Telemetry,
       # Start the PubSub system
       {Phoenix.PubSub, name: Sozisel.PubSub},
+      # Start Presence
+      SoziselWeb.Presence,
       # Start the Endpoint (http/https)
       SoziselWeb.Endpoint,
       # Start absinthe subscriptions handler

--- a/backend/sozisel/lib/sozisel/model/sessions.ex
+++ b/backend/sozisel/lib/sozisel/model/sessions.ex
@@ -321,6 +321,10 @@ defmodule Sozisel.Model.Sessions do
     Repo.get!(Session, id)
   end
 
+  def get_session(id) do
+    Repo.get(Session, id)
+  end
+
   @doc """
   Creates a session.
   """

--- a/backend/sozisel/lib/sozisel_web.ex
+++ b/backend/sozisel/lib/sozisel_web.ex
@@ -17,6 +17,12 @@ defmodule SoziselWeb do
     end
   end
 
+  def channel do
+    quote do
+      use Phoenix.Channel
+    end
+  end
+
   defmacro __using__(which) when is_atom(which) do
     apply(__MODULE__, which, [])
   end

--- a/backend/sozisel/lib/sozisel_web/channels/session_participant_presence.ex
+++ b/backend/sozisel/lib/sozisel_web/channels/session_participant_presence.ex
@@ -1,0 +1,43 @@
+defmodule SoziselWeb.Channels.SessionParticipantsPresence do
+  use SoziselWeb, :channel
+  alias SoziselWeb.Presence
+  alias Sozisel.Model.{Sessions, Sessions.Session}
+
+  # def join("session:participation:" <> session_id, %{"displayName" => display_name}, socket) do
+  #   with %Session{start_time: start_time, end_time: nil} when not is_nil(start_time) <- Sessions.get_session(session_id) do
+  #     send(self(), :after_join)
+  #     {:ok, assign(socket, :display_name, display_name)}
+  #   else
+  #     %Session{start_time: nil} ->
+  #       {:error, "Session has not started yet"}
+
+  #     %Session{} ->
+  #       {:error, "Session has already ended"}
+
+  #     nil ->
+  #       {:error, "Session not found"}
+  #   end
+  # end
+
+  def join("session:participation:" <> session_id, %{"displayName" => display_name}, socket) do
+    send(self(), :after_join)
+    {:ok, assign(socket, :display_name, display_name)}
+  end
+
+  def handle_info(:after_join, socket) do
+    id = Ecto.UUID.generate()
+
+    {:ok, _} =
+      Presence.track(socket, id, %{
+        display_name: socket.assigns.display_name
+      })
+
+    push(socket, "presence_state", Presence.list(socket))
+    {:noreply, assign(socket, :participant_id, id)}
+  end
+
+  def handle_info(%{event: "presence_diff", payload: payload}, socket) do
+    push(socket, "presence_diff", payload)
+    {:noreply, socket}
+  end
+end

--- a/backend/sozisel/lib/sozisel_web/presence.ex
+++ b/backend/sozisel/lib/sozisel_web/presence.ex
@@ -1,0 +1,5 @@
+defmodule SoziselWeb.Presence do
+  use Phoenix.Presence,
+    otp_app: :sozisel,
+    pubsub_server: Sozisel.PubSub
+end

--- a/backend/sozisel/lib/sozisel_web/user_socket.ex
+++ b/backend/sozisel/lib/sozisel_web/user_socket.ex
@@ -1,6 +1,8 @@
 defmodule SoziselWeb.UserSocket do
   use Phoenix.Socket
 
+  channel "session:participation:*", SoziselWeb.Channels.SessionParticipantsPresence
+
   use Absinthe.Phoenix.Socket,
     schema: SoziselWeb.Schema
 

--- a/frontend/sozisel-app/.eslintrc.json
+++ b/frontend/sozisel-app/.eslintrc.json
@@ -17,6 +17,7 @@
   },
   "plugins": ["@typescript-eslint"],
   "rules": {
+    "react/prop-types": [2, { "ignore": ["children"] }],
     "sort-imports": [
       "error",
       {

--- a/frontend/sozisel-app/public/locales/pl/common.json
+++ b/frontend/sozisel-app/public/locales/pl/common.json
@@ -110,6 +110,9 @@
       "shareSession": "Udostępnij sesje",
       "shareSessionInfo": "Każdy z tym linkiem będzie mógł dołączyć do sesji.",
       "shareLabel": "Share link"
+    },
+    "LiveSession": {
+      "placeholder": "Jesteś uczestnikiem trwafjącej sesji."
     }
   },
   "inputErrors": {

--- a/frontend/sozisel-app/src/App.tsx
+++ b/frontend/sozisel-app/src/App.tsx
@@ -1,37 +1,39 @@
 import { Redirect, Route, BrowserRouter as Router } from "react-router-dom";
 
 import AboutScreen from "./components/AboutScreen/AboutScreen";
-import { ApolloProvider } from "@apollo/client";
+import { ApolloProviderWrapper } from "./contexts/ApolloProviderWrapper";
 import AuthRoute from "./components/AuthRoute/AuthRoute";
 import JitsiShowcaseScreen from "./components/Jitsi/JitsiShowcaseScreen";
+import { LiveSession } from "./components/LiveSession/LiveSession";
 import Login from "./components/LoginScreen/LoginScreen";
+import { PhoenixSocketProvider } from "./contexts/PhoenixSocketContext";
 import { ReactElement } from "react";
 import Register from "./components/RegisterScreen/RegisterScreen";
 import SessionsList from "./components/SessionsList/SessionsList";
 import TemplateCreation from "./components/TemplateCreation/TemplateCreation";
 import TemplateList from "./components/TemplatesList/TemplateList";
-import { createApolloClient } from "./apolloClient";
-
-const client = createApolloClient();
 
 export default function App(): ReactElement {
   return (
-    <ApolloProvider client={client}>
-      <Router>
-        <Route exact path="/">
-          <Redirect to="/templates" />
-        </Route>
-        <Route exact path="/jitsi" component={JitsiShowcaseScreen} />
-        <Route exact path="/home">
-          <Redirect to="/templates" />
-        </Route>
-        <AuthRoute path="/templates" component={TemplateList} />
-        <AuthRoute path="/templates/create" component={TemplateCreation} />
-        <AuthRoute path="/sessions" component={SessionsList} />
-        <Route path="/login" component={Login} />
-        <Route path="/register" component={Register} />
-        <Route path="/about" component={AboutScreen} />
-      </Router>
-    </ApolloProvider>
+    <PhoenixSocketProvider>
+      <ApolloProviderWrapper>
+        <Router>
+          <Route exact path="/">
+            <Redirect to="/templates" />
+          </Route>
+          <Route exact path="/jitsi" component={JitsiShowcaseScreen} />
+          <Route exact path="/home">
+            <Redirect to="/templates" />
+          </Route>
+          <AuthRoute path="/templates" component={TemplateList} />
+          <AuthRoute path="/templates/create" component={TemplateCreation} />
+          <AuthRoute path="/sessions" component={SessionsList} />
+          <Route path="/login" component={Login} />
+          <Route path="/register" component={Register} />
+          <Route path="/about" component={AboutScreen} />
+          <Route path="/session/live/:session_id" component={LiveSession} />
+        </Router>
+      </ApolloProviderWrapper>
+    </PhoenixSocketProvider>
   );
 }

--- a/frontend/sozisel-app/src/apolloClient.ts
+++ b/frontend/sozisel-app/src/apolloClient.ts
@@ -22,16 +22,16 @@ function createApolloHttpLink(): ApolloLink {
   return createHttpLink({ uri: `http://${HOST}:4000/api` });
 }
 
-function createApolloSocketLink(): ApolloLink {
-  const socket = createAbsintheSocket(
-    new PhoenixSocket(`ws://${HOST}:4000/socket`)
-  );
+function createApolloSocketLink(phoenixSocket: PhoenixSocket): ApolloLink {
+  const socket = createAbsintheSocket(phoenixSocket);
 
   type MockType = AbsintheSocketLink & ApolloLink;
   return createAbsintheSocketLink(socket) as MockType;
 }
 
-export function createApolloClient(): ApolloClient<NormalizedCacheObject> {
+export function createApolloClient(
+  socket: PhoenixSocket
+): ApolloClient<NormalizedCacheObject> {
   const splitLink = split(
     ({ query }) => {
       const definition = getMainDefinition(query);
@@ -40,7 +40,7 @@ export function createApolloClient(): ApolloClient<NormalizedCacheObject> {
         definition.operation === "subscription"
       );
     },
-    createApolloSocketLink(),
+    createApolloSocketLink(socket),
     createApolloHttpLink()
   );
 

--- a/frontend/sozisel-app/src/components/Jitsi/JitsiFrame.tsx
+++ b/frontend/sozisel-app/src/components/Jitsi/JitsiFrame.tsx
@@ -72,7 +72,7 @@ export default function JitsiFrame({
     if (api) {
       console.log("GOT API");
 
-      (api as any).addEventListener("readyToClose", () => {
+      (api as EventTarget).addEventListener("readyToClose", () => {
         window.location.href = "/";
       });
     }

--- a/frontend/sozisel-app/src/components/LiveSession/LiveSession.scss
+++ b/frontend/sozisel-app/src/components/LiveSession/LiveSession.scss
@@ -1,0 +1,16 @@
+@import "../../styles/styles";
+
+.LiveSession {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+    width: 100%;
+
+    .participantsList {
+        display: flex;
+        flex-direction: column;
+        margin-top: $spacing-04;
+    }
+}

--- a/frontend/sozisel-app/src/components/LiveSession/LiveSession.tsx
+++ b/frontend/sozisel-app/src/components/LiveSession/LiveSession.tsx
@@ -11,13 +11,13 @@ interface LiveSessionParams {
 
 export function LiveSession(): ReactElement {
   const { sessionId } = useParams<LiveSessionParams>();
-  const {t} = useTranslation("common");
+  const { t } = useTranslation("common");
 
   const { participants, error, loading } = useLiveSessionParticipation({
     displayName: "User",
     sessionId,
   });
-  
+
   return (
     <div className="LiveSession">
       <h2>{t("components.LiveSession.placeholder")}</h2>

--- a/frontend/sozisel-app/src/components/LiveSession/LiveSession.tsx
+++ b/frontend/sozisel-app/src/components/LiveSession/LiveSession.tsx
@@ -1,0 +1,33 @@
+import "./LiveSession.scss";
+
+import { ReactElement } from "react";
+import { useLiveSessionParticipation } from "../../hooks/useLiveSessionParticipation";
+import { useParams } from "react-router-dom";
+
+interface LiveSessionParams {
+  sessionId: string;
+}
+
+export function LiveSession(): ReactElement {
+  const { sessionId } = useParams<LiveSessionParams>();
+
+  const { participants, error, loading } = useLiveSessionParticipation({
+    displayName: "User",
+    sessionId,
+  });
+
+  return (
+    <div className="LiveSession">
+      <h2>You are inside live session!</h2>
+      {participants.length > 0 && (
+        <div className="participantsList">
+          {participants.map(({ displayName, key }) => (
+            <div key={key}>{displayName}</div>
+          ))}
+        </div>
+      )}
+      {loading && "Still loading"}
+      {error && error}
+    </div>
+  );
+}

--- a/frontend/sozisel-app/src/components/LiveSession/LiveSession.tsx
+++ b/frontend/sozisel-app/src/components/LiveSession/LiveSession.tsx
@@ -3,6 +3,7 @@ import "./LiveSession.scss";
 import { ReactElement } from "react";
 import { useLiveSessionParticipation } from "../../hooks/useLiveSessionParticipation";
 import { useParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
 interface LiveSessionParams {
   sessionId: string;
@@ -10,15 +11,16 @@ interface LiveSessionParams {
 
 export function LiveSession(): ReactElement {
   const { sessionId } = useParams<LiveSessionParams>();
+  const {t} = useTranslation("common");
 
   const { participants, error, loading } = useLiveSessionParticipation({
     displayName: "User",
     sessionId,
   });
-
+  
   return (
     <div className="LiveSession">
-      <h2>You are inside live session!</h2>
+      <h2>{t("components.LiveSession.placeholder")}</h2>
       {participants.length > 0 && (
         <div className="participantsList">
           {participants.map(({ displayName, key }) => (

--- a/frontend/sozisel-app/src/contexts/ApolloProviderWrapper.tsx
+++ b/frontend/sozisel-app/src/contexts/ApolloProviderWrapper.tsx
@@ -1,0 +1,28 @@
+import {
+  ApolloClient,
+  ApolloProvider,
+  NormalizedCacheObject,
+} from "@apollo/client";
+import { FC, useEffect, useState } from "react";
+import { ensureConnected, usePhoenixSocket } from "./PhoenixSocketContext";
+
+import { createApolloClient } from "../apolloClient";
+
+export const ApolloProviderWrapper: FC = ({ children }) => {
+  const socket = usePhoenixSocket();
+
+  const [client, setClient] = useState<
+    ApolloClient<NormalizedCacheObject> | undefined
+  >();
+
+  useEffect(() => {
+    ensureConnected(socket);
+    setClient(createApolloClient(socket));
+  }, [socket, setClient]);
+
+  if (!client) {
+    return <></>;
+  }
+
+  return <ApolloProvider client={client}>{children}</ApolloProvider>;
+};

--- a/frontend/sozisel-app/src/contexts/PhoenixSocketContext.tsx
+++ b/frontend/sozisel-app/src/contexts/PhoenixSocketContext.tsx
@@ -1,0 +1,32 @@
+import { FC, createContext, useContext, useMemo } from "react";
+
+import { Socket } from "phoenix";
+
+const Context = createContext<Socket | undefined>(undefined);
+
+export function usePhoenixSocket(): Socket {
+  const socket = useContext(Context);
+
+  if (!socket) {
+    throw new Error("Socket has not been set up.");
+  }
+
+  return socket;
+}
+
+export const PhoenixSocketProvider: FC = ({ children }) => {
+  const socket = useMemo(() => {
+    const sock = new Socket(`ws://${window.location.hostname}:4000/socket`);
+    sock.connect();
+    return sock;
+  }, []);
+
+  return <Context.Provider value={socket}>{children}</Context.Provider>;
+};
+
+export function ensureConnected(socket: Socket): Socket {
+  if (!socket.isConnected()) {
+    socket.connect();
+  }
+  return socket;
+}

--- a/frontend/sozisel-app/src/hooks/useLiveSessionParticipation.ts
+++ b/frontend/sozisel-app/src/hooks/useLiveSessionParticipation.ts
@@ -1,0 +1,91 @@
+import {
+  ensureConnected,
+  usePhoenixSocket,
+} from "../contexts/PhoenixSocketContext";
+import { useEffect, useState } from "react";
+
+interface Config {
+  sessionId: string;
+  displayName: string;
+}
+
+interface Participant {
+  key: string;
+  displayName: string;
+}
+
+interface Participation {
+  participants: Participant[];
+  loading: boolean;
+  error?: string;
+}
+
+interface PresenceEntry {
+  metas: { display_name: string; phx_ref: string }[];
+}
+
+export function useLiveSessionParticipation({
+  displayName,
+  sessionId,
+}: Config): Participation {
+  const socket = usePhoenixSocket();
+
+  const [participation, setParticipation] = useState<Participation>({
+    participants: [],
+    loading: true,
+    error: undefined,
+  });
+
+  useEffect(() => {
+    ensureConnected(socket);
+
+    const channel = socket.channel(`session:participation:${sessionId}`, {
+      displayName,
+    });
+
+    channel
+      .join()
+      .receive("ok", () => setParticipation((p) => ({ ...p, loading: false })))
+      .receive("error", (error) =>
+        setParticipation((p) => ({ ...p, loading: false, error }))
+      );
+
+    channel.on("presence_state", (state) => {
+      const participants = Object.entries(state).map(parsePresenceEntry);
+
+      setParticipation((p) => ({ ...p, participants: participants }));
+    });
+
+    channel.on("presence_diff", ({ joins, leaves }) => {
+      const joiningParticipants = Object.entries(joins).map(parsePresenceEntry);
+      const leavingParticipantKeys = Object.entries(leaves)
+        .map(parsePresenceEntry)
+        .map(({ key }) => key);
+
+      setParticipation((p) => {
+        return {
+          ...p,
+          participants: [
+            ...p.participants.filter(
+              ({ key }) => !leavingParticipantKeys.includes(key)
+            ),
+            ...joiningParticipants,
+          ],
+        };
+      });
+    });
+
+    return () => {
+      channel.leave();
+    };
+  }, [socket, setParticipation, displayName, sessionId]);
+
+  return participation;
+}
+
+function parsePresenceEntry([key, entry]: [string, unknown]): Participant {
+  const {
+    metas: [meta],
+  } = entry as PresenceEntry;
+  return { displayName: meta.display_name, key };
+}

--- a/frontend/sozisel-app/src/hooks/useLiveSessionParticipation.ts
+++ b/frontend/sozisel-app/src/hooks/useLiveSessionParticipation.ts
@@ -63,13 +63,18 @@ export function useLiveSessionParticipation({
         .map(({ key }) => key);
 
       setParticipation((p) => {
+        const currentParticipantKeys = p.participants.map(({ key }) => key);
+        const newParticipants = joiningParticipants.filter(
+          ({ key }) => !currentParticipantKeys.includes(key)
+        );
+
         return {
           ...p,
           participants: [
             ...p.participants.filter(
               ({ key }) => !leavingParticipantKeys.includes(key)
             ),
-            ...joiningParticipants,
+            ...newParticipants,
           ],
         };
       });


### PR DESCRIPTION
This PR introduces live session participants presence. It implements auto refreshed list of currently active session participants. Some code will be commented out for now and should be fixed when we start to handle live sessions for real.

The subscription is done via phoenix channel instead of graphql subscription as the `Phoenix.Presence` module can't be easily used with subscriptions without some next level hacking. 

It is a part of #70.