### PR TITLE
Fixed event subscription tests

### DIFF
--- a/backend/sozisel/config/test.exs
+++ b/backend/sozisel/config/test.exs
@@ -15,4 +15,4 @@ config :sozisel, SoziselWeb.Endpoint,
 config :bcrypt_elixir, log_rounds: 4
 
 # Print only warnings and errors during test
-config :logger, level: :warn
+config :logger, level: :error

--- a/backend/sozisel/lib/sozisel/model/events.ex
+++ b/backend/sozisel/lib/sozisel/model/events.ex
@@ -10,9 +10,7 @@ defmodule Sozisel.Model.Events do
   alias Sozisel.Model.EventResults.EventResult
   alias Sozisel.Model.Events.Event
   alias Sozisel.Model.LaunchedEvents.LaunchedEvent
-  alias Sozisel.Model.Polls.Poll
   alias Sozisel.Model.Utils
-  alias Sozisel.Model.Quizzes.Quiz
 
   def list_events do
     Repo.all(Event)

--- a/backend/sozisel/lib/sozisel_web/context.ex
+++ b/backend/sozisel/lib/sozisel_web/context.ex
@@ -51,6 +51,7 @@ defmodule SoziselWeb.Context do
           nil
 
         _ ->
+          Logger.warn("Bearer token is missing in authorization params...")
           nil
       end
 
@@ -63,7 +64,8 @@ defmodule SoziselWeb.Context do
       with {:ok, user} <- authorize(token) do
         user
       else
-        _ ->
+        {:error, :invalid_token} ->
+          Logger.warn("Failed to authorize user, invalid token")
           nil
       end
 
@@ -71,6 +73,7 @@ defmodule SoziselWeb.Context do
   end
 
   def build_context(_args) do
+    Logger.warn("Context has been created without any parameters...")
     %{}
   end
 

--- a/backend/sozisel/lib/sozisel_web/schema/resolvers/participant_resolvers.ex
+++ b/backend/sozisel/lib/sozisel_web/schema/resolvers/participant_resolvers.ex
@@ -125,22 +125,27 @@ defmodule SoziselWeb.Schema.Resolvers.ParticipantResolvers do
             participant_answers
             |> Enum.find(&(&1.question_id == event_question.id))
 
-          correct_answers_ids =
-            event_question.correct_answers
-            |> Enum.map(& &1.id)
+          if answer_on_question != nil do
+            correct_answers_ids =
+              event_question.correct_answers
+              |> Enum.map(& &1.id)
 
-          track_nodes =
-            answer_on_question.track_nodes
-            |> Enum.map(&struct(TrackNode, &1))
+            track_nodes =
+              answer_on_question.track_nodes
+              |> Enum.map(&struct(TrackNode, &1))
 
-          %ParticipantAnswer{
-            question_id: event_question.id,
-            final_answer_ids: answer_on_question.final_answer_ids,
-            is_correct:
-              Enum.sort(answer_on_question.final_answer_ids) == Enum.sort(correct_answers_ids),
-            track_nodes: track_nodes
-          }
+            %ParticipantAnswer{
+              question_id: event_question.id,
+              final_answer_ids: answer_on_question.final_answer_ids,
+              is_correct:
+                Enum.sort(answer_on_question.final_answer_ids) == Enum.sort(correct_answers_ids),
+              track_nodes: track_nodes
+            }
+          else
+            nil
+          end
         end)
+        |> Enum.reject(&is_nil(&1))
 
       with {:ok, event_result} <-
              %{

--- a/backend/sozisel/lib/sozisel_web/schema/resolvers/presenter_resolvers.ex
+++ b/backend/sozisel/lib/sozisel_web/schema/resolvers/presenter_resolvers.ex
@@ -20,6 +20,7 @@ defmodule SoziselWeb.Schema.Resolvers.PresenterResolvers do
     %{
       id: launched_event.id,
       name: event.name,
+      duration_time_sec: event.duration_time_sec,
       event_data: event.event_data
     }
   end

--- a/backend/sozisel/lib/sozisel_web/schema/types/event_types.ex
+++ b/backend/sozisel/lib/sozisel_web/schema/types/event_types.ex
@@ -73,6 +73,7 @@ defmodule SoziselWeb.Schema.Types.EventTypes do
   object :participant_event do
     field :id, non_null(:id)
     field :name, non_null(:string)
+    field :duration_time_sec, non_null(:integer)
 
     field :event_data, non_null(:participant_event_data)
   end

--- a/backend/sozisel/lib/sozisel_web/schema/types/quiz_types.ex
+++ b/backend/sozisel/lib/sozisel_web/schema/types/quiz_types.ex
@@ -39,7 +39,6 @@ defmodule SoziselWeb.Schema.Types.QuizTypes do
   # ==== PARTICIPANT QUIZ ======
 
   object :participant_quiz do
-    field :duration_time_sec, non_null(:integer)
     field :quiz_questions, strong_list_of(:participant_quiz_question)
   end
 

--- a/backend/sozisel/test/sozisel_web/schema/events/event_subscriptions_test.exs
+++ b/backend/sozisel/test/sozisel_web/schema/events/event_subscriptions_test.exs
@@ -1,10 +1,6 @@
 defmodule SoziselWeb.Schema.Events.EventSubscriptionsTest do
   use SoziselWeb.AbsintheCase
 
-  alias Sozisel.Model.Quizzes.{QuizResult, ParticipantAnswer}
-  alias Sozisel.Model.Polls.PollResult
-  alias Sozisel.Model.EventResults.EventResult
-
   import Sozisel.Factory
 
   @launch_event_mutation """

--- a/backend/sozisel/test/sozisel_web/schema/events/event_subscriptions_test.exs
+++ b/backend/sozisel/test/sozisel_web/schema/events/event_subscriptions_test.exs
@@ -1,13 +1,35 @@
 defmodule SoziselWeb.Schema.Events.EventSubscriptionsTest do
   use SoziselWeb.AbsintheCase
 
-  alias SoziselWeb.Schema.Helpers
-  alias SoziselWeb.Schema.Subscriptions.Topics
   alias Sozisel.Model.Quizzes.{QuizResult, ParticipantAnswer}
   alias Sozisel.Model.Polls.PollResult
   alias Sozisel.Model.EventResults.EventResult
 
   import Sozisel.Factory
+
+  @launch_event_mutation """
+  mutation LaunchEvent($eventId: ID!, $sessionId: ID!, $broadcast: Boolean, $targetParticipants: [ID]) {
+    launchEvent(eventId: $eventId, sessionId: $sessionId, broadcast: $broadcast, targetParticipants: $targetParticipants) {
+      id
+    }
+  }
+  """
+
+  @submit_quiz_results """
+  mutation SubmitQuizResult($token: String!, $input: QuizResultInput!) {
+    submitQuizResults(token: $token, input: $input) {
+      id
+    }
+  }
+  """
+
+  @submit_poll_result """
+  mutation SubmitPollResult($token: String!, $input: PollResultInput!) {
+    submitPollResult(token: $token, input: $input) {
+      id
+    }
+  }
+  """
 
   @participant_event_launched """
   subscription EventLaunched($participantToken: String!) {
@@ -77,64 +99,32 @@ defmodule SoziselWeb.Schema.Events.EventSubscriptionsTest do
   }
   """
 
-  def mock_participant_event(session \\ nil, type) do
-    attrs =
-      if session == nil do
-        %{}
-      else
-        %{session_id: session.id}
-      end
-
+  def mock_participant_event(session_template, type) do
     case type do
-      :poll -> build(:poll_event, attrs)
-      :quiz -> build(:quiz_event, attrs)
+      :poll -> insert(:poll_event, session_template_id: session_template.id)
+      :quiz -> insert(:quiz_event, session_template_id: session_template.id)
     end
-  end
-
-  def mock_quiz_event_result(session, event, participant) do
-    launched_event = insert(:launched_event, event_id: event.id, session_id: session.id)
-
-    %EventResult{
-      id: Ecto.UUID.generate(),
-      participant_id: participant.id,
-      launched_event_id: launched_event.id,
-      result_data: %QuizResult{
-        participant_answers: [
-          %ParticipantAnswer{
-            question_id: "some id",
-            final_answer_ids: ["some answer id"],
-            is_correct: false,
-            track_nodes: []
-          }
-        ]
-      }
-    }
-    |> Repo.insert()
-    |> elem(1)
-  end
-
-  def mock_poll_event_result(session, event, participant) do
-    launched_event = insert(:launched_event, event_id: event.id, session_id: session.id)
-
-    %EventResult{
-      id: Ecto.UUID.generate(),
-      participant_id: participant.id,
-      launched_event_id: launched_event.id,
-      result_data: %PollResult{
-        option_ids: ["1"]
-      }
-    }
-    |> Repo.insert()
-    |> elem(1)
   end
 
   describe "Event subscriptions should" do
     setup do
       user = insert(:user)
-      session = insert(:session, user_id: user.id)
+      user_socket = test_socket(user)
+      user_conn = test_conn(user)
+
+      session_template = insert(:template, user_id: user.id)
+      session = insert(:session, session_template_id: session_template.id, user_id: user.id)
+
       participant = insert(:participant, session_id: session.id)
 
-      [session: session, participant: participant, user: user]
+      [
+        session: session,
+        session_template: session_template,
+        participant: participant,
+        user: user,
+        user_socket: user_socket,
+        user_conn: user_conn
+      ]
     end
 
     test "broadcast event launched event to a proper participant", ctx do
@@ -146,12 +136,14 @@ defmodule SoziselWeb.Schema.Events.EventSubscriptionsTest do
 
       sub = run_subscription(socket, @participant_event_launched, variables)
 
-      # broadcast to all participants in session
-      Helpers.subscription_publish(
-        :event_launched,
-        Topics.session_all_participants(ctx.session.id),
-        mock_participant_event(:quiz)
-      )
+      quiz = mock_participant_event(ctx.session_template, :quiz)
+
+      assert %{data: %{"launchEvent" => %{"id" => _launched_event_id}}} =
+               run_query(ctx.user_conn, @launch_event_mutation, %{
+                 sessionId: ctx.session.id,
+                 eventId: quiz.id,
+                 broadcast: true
+               })
 
       assert %{
                data: %{
@@ -163,12 +155,17 @@ defmodule SoziselWeb.Schema.Events.EventSubscriptionsTest do
                }
              } = receive_subscription(sub)
 
+      alias Sozisel.Model.LaunchedEvents.LaunchedEvent
+      Repo.delete_all(LaunchedEvent)
+
       # broadcast to a single participant
-      Helpers.subscription_publish(
-        :event_launched,
-        Topics.session_participant(ctx.session.id, ctx.participant.id),
-        mock_participant_event(:quiz)
-      )
+      assert %{data: %{"launchEvent" => %{"id" => _launched_event_id}}} =
+               run_query(ctx.user_conn, @launch_event_mutation, %{
+                 sessionId: ctx.session.id,
+                 eventId: quiz.id,
+                 broadcast: false,
+                 targetParticipants: [ctx.participant.id]
+               })
 
       assert %{
                data: %{
@@ -182,22 +179,29 @@ defmodule SoziselWeb.Schema.Events.EventSubscriptionsTest do
     end
 
     test "broadcast quiz event result submitted event back to presenter", ctx do
-      template = insert(:template)
-      event = insert(:quiz_event, session_template_id: template.id)
-
-      socket = test_socket(ctx.user)
+      event = insert(:quiz_event, session_template_id: ctx.session_template.id)
+      launched_event = insert(:launched_event, event_id: event.id, session_id: ctx.session.id)
 
       variables = %{
         sessionId: ctx.session.id
       }
 
-      sub = run_subscription(socket, @presenter_event_result_submitted, variables)
+      sub = run_subscription(ctx.user_socket, @presenter_event_result_submitted, variables)
 
-      Helpers.subscription_publish(
-        :event_result_submitted,
-        Topics.session_presenter(ctx.session.id, ctx.user.id),
-        mock_quiz_event_result(ctx.session, event, ctx.participant)
-      )
+      assert %{data: %{}} =
+               run_query(test_conn(), @submit_quiz_results, %{
+                 token: ctx.participant.token,
+                 input: %{
+                   launched_event_id: launched_event.id,
+                   participant_answers: [
+                     %{
+                       question_id: "1",
+                       final_answer_ids: ["1"],
+                       track_nodes: []
+                     }
+                   ]
+                 }
+               })
 
       participant_id = ctx.participant.id
       event_id = event.id
@@ -223,22 +227,23 @@ defmodule SoziselWeb.Schema.Events.EventSubscriptionsTest do
     end
 
     test "broadcast poll event result back to presenter", ctx do
-      template = insert(:template)
-      event = insert(:poll_event, session_template_id: template.id)
-
-      socket = test_socket(ctx.user)
+      event = insert(:poll_event, session_template_id: ctx.session_template.id)
+      launched_event = insert(:launched_event, event_id: event.id, session_id: ctx.session.id)
 
       variables = %{
         sessionId: ctx.session.id
       }
 
-      sub = run_subscription(socket, @presenter_event_result_submitted, variables)
+      sub = run_subscription(ctx.user_socket, @presenter_event_result_submitted, variables)
 
-      Helpers.subscription_publish(
-        :event_result_submitted,
-        Topics.session_presenter(ctx.session.id, ctx.user.id),
-        mock_poll_event_result(ctx.session, event, ctx.participant)
-      )
+      assert %{data: %{}} =
+               run_query(test_conn(), @submit_poll_result, %{
+                 token: ctx.participant.token,
+                 input: %{
+                   launched_event_id: launched_event.id,
+                   poll_option_ids: ["1"]
+                 }
+               })
 
       assert %{
                data: %{
@@ -322,7 +327,10 @@ defmodule SoziselWeb.Schema.Events.EventSubscriptionsTest do
   describe "Launching all events" do
     setup do
       user = insert(:user)
-      session = insert(:session, user_id: user.id)
+      user_conn = test_conn(user)
+
+      session_template = insert(:template, user_id: user.id)
+      session = insert(:session, session_template_id: session_template.id, user_id: user.id)
       participant = insert(:participant, session_id: session.id)
 
       variables = %{
@@ -331,15 +339,25 @@ defmodule SoziselWeb.Schema.Events.EventSubscriptionsTest do
 
       sub = run_subscription(test_socket(), @participant_event_launched, variables)
 
-      [session: session, participant: participant, user: user, subscription: sub]
+      [
+        session: session,
+        session_template: session_template,
+        participant: participant,
+        user: user,
+        user_conn: user_conn,
+        subscription: sub
+      ]
     end
 
     test "quiz", ctx do
-      Helpers.subscription_publish(
-        :event_launched,
-        Topics.session_all_participants(ctx.session.id),
-        mock_participant_event(:quiz)
-      )
+      quiz = mock_participant_event(ctx.session_template, :quiz)
+
+      assert %{data: %{}} =
+               run_query(ctx.user_conn, @launch_event_mutation, %{
+                 sessionId: ctx.session.id,
+                 eventId: quiz.id,
+                 broadcast: true
+               })
 
       assert %{
                data: %{
@@ -354,11 +372,14 @@ defmodule SoziselWeb.Schema.Events.EventSubscriptionsTest do
     end
 
     test "poll", ctx do
-      Helpers.subscription_publish(
-        :event_launched,
-        Topics.session_all_participants(ctx.session.id),
-        mock_participant_event(:poll)
-      )
+      poll = mock_participant_event(ctx.session_template, :poll)
+
+      assert %{data: %{}} =
+               run_query(ctx.user_conn, @launch_event_mutation, %{
+                 sessionId: ctx.session.id,
+                 eventId: poll.id,
+                 broadcast: true
+               })
 
       assert %{
                data: %{

--- a/frontend/sozisel-app/src/components/ParticipantActiveSession/Modules/QuizEvent/ParticipantQuizEvent.tsx
+++ b/frontend/sozisel-app/src/components/ParticipantActiveSession/Modules/QuizEvent/ParticipantQuizEvent.tsx
@@ -46,7 +46,7 @@ export default function ParticipantQuizEvent({
   };
 
   const countdownTimer = useCountdownTimer({
-    startValue: quiz.durationTimeSec,
+    startValue: event.durationTimeSec,
     onFinishCallback: submit,
   });
 

--- a/frontend/sozisel-app/src/contexts/PhoenixSocketContext.tsx
+++ b/frontend/sozisel-app/src/contexts/PhoenixSocketContext.tsx
@@ -1,6 +1,7 @@
 import { FC, createContext, useContext, useMemo } from "react";
 
 import { Socket } from "phoenix";
+import { USER_TOKEN } from "../common/consts";
 
 const Context = createContext<Socket | undefined>(undefined);
 
@@ -16,7 +17,10 @@ export function usePhoenixSocket(): Socket {
 
 export const PhoenixSocketProvider: FC = ({ children }) => {
   const socket = useMemo(() => {
-    const sock = new Socket(`ws://${window.location.hostname}:4000/socket`);
+    const token = localStorage.getItem(USER_TOKEN);
+    const sock = new Socket(`ws://${window.location.hostname}:4000/socket`, {
+      params: { token },
+    });
     sock.connect();
     return sock;
   }, []);

--- a/frontend/sozisel-app/src/graphql/subscriptions/session.graphql
+++ b/frontend/sozisel-app/src/graphql/subscriptions/session.graphql
@@ -8,6 +8,7 @@ subscription EventLaunched($token: String!){
     eventLaunched(participantToken: $token){
         id
         name
+        durationTimeSec
         eventData {
             ... participantQuizFields
             ... pollFields
@@ -17,7 +18,6 @@ subscription EventLaunched($token: String!){
 
 fragment participantQuizFields on ParticipantQuiz {
     __typename
-    durationTimeSec
     quizQuestions {
         id
         question


### PR DESCRIPTION
This PR fixes bugs regarding event subscription tests as those did not test if correct events got triggered on graphql mutations. 
Also fixed types regarding `:participant_event` as it was missing newly added `duration_time_sec` and it caused errors on frontend side. 
Besides that, also added user token as a socket param when connecting with `PhoenixSocket`, the lack of the token was causing unauthorized error in presenter's subscriptions.